### PR TITLE
Add the ability to set the em size for breakpoint calculations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Utility functions for creating breakpoints in `styled-components` 💅.
 ## Installation
 
     npm install --save styled-components styled-components-breakpoint
-    
+
 ## Usage
 
 ### Using the default breakpoints
@@ -20,17 +20,17 @@ const Heading = styled.h1`
 
   color: #444;
   font-family: sans-serif;
-  
+
   font-size: 12px;
-  
+
   ${breakpoint('tablet')`
     font-size: 16px;
   `}
-  
+
   ${breakpoint('desktop')`
     font-size: 24px;
   `}
-  
+
 `;
 
 export default Heading;
@@ -59,19 +59,19 @@ const Heading = styled.h1`
 
   color: #444;
   font-family: sans-serif;
-  
+
   ${({theme}) => breakpoint('sm', theme.breakpoints)`
     font-size: 12px;
   `}
-  
+
   ${({theme}) => breakpoint('md', theme.breakpoints)`
     font-size: 16px;
   `}
-  
+
   ${({theme}) => breakpoint('lg', theme.breakpoints)`
     font-size: 24px;
   `}
-  
+
 `;
 
 export default Heading;
@@ -85,7 +85,7 @@ import React from 'react';
 import {ThemeProvider} from 'styled-components';
 
 const theme = {
-  breakpoints: { 
+  breakpoints: {
     xs: 0,
     sm: 576,
     md: 768,
@@ -108,7 +108,8 @@ Wraps rules in a `@media` block.
 
 **Properties:**
 - `name` - A `string`. The name of a configured breakpoint.
-- `breakpoints` - An `object`.
+- `breakpoints` - [Optional] An `object`.
+- `em` - [Optional] A `number`. Font-size in pixels of one em.
 
 ##### Example:
 ```js
@@ -126,7 +127,7 @@ const Thing = styled.div`
   ${breakpoint('desktop')`
     font-size: 24px;
   `};
-  
+
 `;
 
 <Thing/>
@@ -161,6 +162,7 @@ Maps rules at multiple breakpoints to `@media` blocks.
 - `value` - An `object` or `*`. A map of values to names of configured breakpoints.
 - `mapValueToCSS` - A `function`. The function is called for each breakpoint and is passed the value for the specific breakpoint.
 - `breakpoints` - An `object`.
+- `em` - [Optional] A `number`. Font-size in pixels of one em.
 
 **Returns:**
 
@@ -198,16 +200,19 @@ const Thing = styled.div`
 }
 ```
 
-## Default breakpoints
+## Default Values
 
-These are the default breakpoints provided:
+These are the default values provided:
 
 ```js
+// Breakpoints
 {
-    mobile: 0,      //targeting all devices
-    tablet: 737,    //targeting devices that are larger than the iPhone 6 Plus (which is 736px in landscape mode)
-    desktop: 1025   //targeting devices that are larger than the iPad (which is 1024px in landscape mode)
+    mobile: 0,      // Targeting all devices.
+    tablet: 737,    // Targeting devices that are larger than the iPhone 6 Plus (which is 736px in landscape mode).
+    desktop: 1025   // Targeting devices that are larger than the iPad (which is 1024px in landscape mode).
 }
+// Em Value
+const em = 16 // Typical base value for font-size in pixels.
 ```
 
 ## Change log
@@ -229,7 +234,7 @@ Breaking changes:
   - `value` is an `object`
 
   before:
-  
+
   ```js
   const Grid = styled.div`
     ${({wrap}) => map(wrap, value => `flex-wrap: ${value && 'wrap' || 'nowrap'};`)}
@@ -243,7 +248,7 @@ Breaking changes:
   <Grid wrap={true}/> //works
   <Grid wrap={false}/> //works
   <Grid wrap={{mobile: true, tablet: false}}/> //works
-  
+
   /*
     This breaks because no value is set for the `mobile` breakpoint and CSS defaults to `nowrap`. This is easily fixed
     by manually setting `flex-wrap: wrap;` outside of the `map()` for all breakpoints... but for complex fns this may require
@@ -254,7 +259,7 @@ Breaking changes:
   ```
 
   after:
-  
+
   ```js
   const Grid = styled.div`
     ${({wrap}) => map(wrap, (value = true) => `flex-wrap: ${value && 'wrap' || 'nowrap'};`)}

--- a/src/index.js
+++ b/src/index.js
@@ -1,21 +1,24 @@
 import {css} from 'styled-components';
 
 const defaultBreakpoints = {
-  mobile: 0,      //targeting all devices
-  tablet: 737,    //targeting devices that are LARGER than the iPhone 6 Plus (which is 736px in landscape mode)
-  desktop: 1025   //targeting devices that are LARGER than the iPad (which is 1024px in landscape mode)
+  mobile: 0,      // Targeting all devices.
+  tablet: 737,    // Targeting devices that are LARGER than the iPhone 6 Plus (which is 736px in landscape mode).
+  desktop: 1025   // Targeting devices that are LARGER than the iPad (which is 1024px in landscape mode).
 };
+
+const defaultEm = 16; // One em in pixels.
 
 /**
  * @param   {string}    name
  * @param   {object}    [breakpoints]
+ * @param   {number}    em
  * @returns {*}
  */
-const breakpoint = (name, breakpoints = defaultBreakpoints) => {
+const breakpoint = (name, breakpoints = defaultBreakpoints, em = defaultEm) => {
   let breakpoint = breakpoints[name];
 
   if (typeof breakpoint === 'number') {
-    breakpoint = `${breakpoint / 16}em`; //assume number is px and convert to 'em's
+    breakpoint = `${breakpoint / em}em`; //assume number is px and convert to 'em's
   }
 
   //special case for 0 to avoid wrapping in an unnecessary @media
@@ -33,15 +36,16 @@ const breakpoint = (name, breakpoints = defaultBreakpoints) => {
  * @param   {*|object}  value
  * @param   {function}  mapValueToCSS
  * @param   {object}    [breakpoints]
+ * @param   {number}    em
  * @returns {*}
  */
-export const map = (value, mapValueToCSS, breakpoints) => {
+export const map = (value, mapValueToCSS, breakpoints, em) => {
   const type = typeof value;
 
   if (type === 'object') {
     return [
       mapValueToCSS(undefined), //set the default value
-      ...Object.keys(value).map(key => breakpoint(key, breakpoints)(...mapValueToCSS(value[key])))
+      ...Object.keys(value).map(key => breakpoint(key, breakpoints, em)(...mapValueToCSS(value[key])))
     ];
   } else {
     return mapValueToCSS(value);


### PR DESCRIPTION
Updated the default `breakpoint()` and `map()` implementations to have the ability to take in a custom pixel value for _em_.

Primarily geared toward leveraging the default breakpoints but with a different base _em_ value depending on the UI needs.