### PR TITLE
Add Generics to breakpoint

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,9 +21,9 @@ type ComponentProps = {
   }
 };
 
-function breakpoint(gte: string, lt?: string) {
+function breakpoint<T = {}>(gte: string, lt?: string) {
   return function (strings: string[], ...interpolations: StyledComponentsInterpolation[]) {
-    return function ({ theme = {} }: ComponentProps) {
+    return function ({ theme = {} }: T & ComponentProps) {
       return _breakpoint(theme.breakpoints || defaultBreakpoints, gte, lt)(strings, ...interpolations);
     };
   };


### PR DESCRIPTION
You'll have to forgive me if this is failing to build, I've cloned locally but usually I work with TS not flow and haven't been able to get it to run. 

Anyway, motivation for this is as follows:

```typescript
interface Props {
  readonly maxWidth: string;
}

const Comp = styled.div<Props>`
  ${(props) => {
    // TS doesn't mind
    console.log({ props: props.maxWidth });

    return null;
  }}

  ${breakpoint("tablet")`
    ${(p) => {
      // TS doesn't like bc of breakpoint args
      if (p.maxWidth) {
        return `max-width: ${p.maxWidth}`;
      }

      return null;
    }}
  `}
`;
```

This change enables you to pass the types into breakpoint


```typescript
interface Props {
  readonly maxWidth: string;
}

const Comp = styled.div<Props>`
  ${breakpoint<Props>("tablet")`
    ${(p) => {
      // TS happy
      if (p.maxWidth) {
        return `max-width: ${p.maxWidth}`;
      }

      return null;
    }}
  `}
`;
```
